### PR TITLE
bugfix: wrong time in timeupdated column

### DIFF
--- a/classes/table/report.php
+++ b/classes/table/report.php
@@ -145,7 +145,7 @@ class report extends \table_sql {
         if ($record->timeupdated) {
             return userdate($record->timeupdated, get_string('strftimedatetimeshort'))
                 . '<br>'
-                . format_time(time() - $record->timecreated);
+                . format_time(time() - $record->timeupdated);
         } else {
             return  '-';
         }


### PR DESCRIPTION
**Issue**
- The code for this column was presumably copied from the `timecreated` column.
- The relative time part was accidentally left as subtracting `timecreated` and not `timeupdated`, so the times displayed were wrong.

**Fix**
- Use the right time value